### PR TITLE
docs: add Project Blog link to README navigation

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,8 @@ TLS/SSL scanning tools for security professionals and developers
 
 [Documentation](docs/DeepVioletTools.md) |
 [Changes from Upstream](docs/CHANGES.md) |
-[DeepViolet API](https://github.com/spoofzu/DeepViolet/)
+[DeepViolet API](https://github.com/spoofzu/DeepViolet/) |
+[Project Blog](https://www.sipsjava.com/blog/)
 
 ---
 


### PR DESCRIPTION
## Summary
- Add Project Blog link (https://www.sipsjava.com/blog/) to README navigation bar

## Test plan
- [ ] Verify README renders correctly on GitHub
- [ ] Verify all navigation links resolve

🤖 Generated with [Claude Code](https://claude.ai/claude-code)